### PR TITLE
Fix #191 - Cannot extract outputs from seed reprocessor

### DIFF
--- a/src/main/java/com/blakebr0/mysticalagriculture/tileentity/reprocessor/TileEssenceReprocessor.java
+++ b/src/main/java/com/blakebr0/mysticalagriculture/tileentity/reprocessor/TileEssenceReprocessor.java
@@ -221,7 +221,7 @@ public abstract class TileEssenceReprocessor extends TileEntityUtil implements I
 
 	@Override
 	public int[] getSlotsForFace(EnumFacing side) {
-		return side == EnumFacing.UP ? new int[] { 0 } : side == EnumFacing.DOWN ? new int[] { 1 } : new int[] { 0, 1 };
+		return side == EnumFacing.UP ? new int[] { 0 } : side == EnumFacing.DOWN ? new int[] { 2 } : new int[] { 1 };
 	}
 
 	@Override


### PR DESCRIPTION
Slot 1 is the fuel slot.

With this change, the reprocessor can be automated just like a vanilla Furnace, with inputs going into the top face, outputs coming out of the bottom face, and fuel going into any of the other four sides.