### PR TITLE
[Myst.Agr.] Added a json for mod compatibility with Public Gui Announcement

### DIFF
--- a/src/main/resources/assets/mysticalagriculture/load_screens/pga_compat.json
+++ b/src/main/resources/assets/mysticalagriculture/load_screens/pga_compat.json
@@ -1,0 +1,8 @@
+{
+	"screens" : [{
+			"COMMENT" : "Public Gui Anouncement Support", 
+			"class" : "com.blakebr0.mysticalagriculture.container.TinkeringTableContainer", 
+			"texture" : "mysticalagriculture:textures/gui/tinkering_table.png", 
+			"size" : [175, 200]
+		}]
+}


### PR DESCRIPTION
the PGA :
https://www.curseforge.com/minecraft/mc-mods/public-gui-announcement

The Wiki on how these JSON files work :
https://github.com/ArtixAllMighty/PublicGuiAnnouncement/wiki/Add-Mod-Compatibility

In this PR is contained one json file to add compatibility with the mod Public Gui Announcement.
I wanted to ship the compat at first with my mod, but it would be better if the author maintains it himself. (in case of path and name changes as well addition or removal from screens).

I hereby give you all files needed to add compatibility to my mod. There is nothing else left to do apart from merging the PR.

If you have any other question, I'd be happy to answer !

ps : no need to add the furnace screens, they will hook into the vanilla screens because you use the vanilla container !