### PR TITLE
Fix Awakening recipes with less than 4 essence items preventing world join

### DIFF
--- a/src/main/java/com/blakebr0/mysticalagriculture/crafting/recipe/AwakeningRecipe.java
+++ b/src/main/java/com/blakebr0/mysticalagriculture/crafting/recipe/AwakeningRecipe.java
@@ -301,7 +301,7 @@ public class AwakeningRecipe implements IAwakeningRecipe {
             var essences = NonNullList.withSize(size, ItemStack.EMPTY);
 
             for (int i = 0; i < size; i++) {
-                essences.set(i, ItemStack.STREAM_CODEC.decode(buffer));
+                essences.set(i, ItemStack.OPTIONAL_STREAM_CODEC.decode(buffer));
             }
 
             var result = ItemStack.STREAM_CODEC.decode(buffer);
@@ -323,7 +323,7 @@ public class AwakeningRecipe implements IAwakeningRecipe {
             buffer.writeVarInt(4);
 
             for (int i = 0; i < 4; i++) {
-                ItemStack.STREAM_CODEC.encode(buffer, recipe.essences.get(i));
+                ItemStack.OPTIONAL_STREAM_CODEC.encode(buffer, recipe.essences.get(i));
             }
 
             ItemStack.STREAM_CODEC.encode(buffer, recipe.result);


### PR DESCRIPTION
The issue was caused due to
1. always sending and receiving 4  ItemStacks even though some ItemStacks may be empty
2. the default Codec provided by minecraft doesn't allow empty ItemStacks

To solve the issue i changed the used codec to the optional one.
