### PR TITLE
Added output slots for Essence Furnace

### DIFF
--- a/src/main/java/com/blakebr0/mysticalagriculture/tileentity/EssenceFurnaceTileEntity.java
+++ b/src/main/java/com/blakebr0/mysticalagriculture/tileentity/EssenceFurnaceTileEntity.java
@@ -256,6 +256,8 @@ public class EssenceFurnaceTileEntity extends BaseInventoryTileEntity implements
     }
 
     public static BaseItemStackHandler createInventoryHandler(OnContentsChangedFunction onContentsChanged) {
-        return BaseItemStackHandler.create(3, onContentsChanged, builder -> {});
+        return BaseItemStackHandler.create(3, onContentsChanged, builder -> {
+            builder.setOutputSlots(2);
+        });
     }
 }


### PR DESCRIPTION
Essence Furnace didn't have any slots defined for output -- this fixes it so it can be pulled from automatically.

As a note, without this fix, automated systems pull from *every* slot.