### PR TITLE
Allow fuel extraction on HarvesterTileEntity.java

### DIFF
--- a/src/main/java/com/blakebr0/mysticalagriculture/tileentity/HarvesterTileEntity.java
+++ b/src/main/java/com/blakebr0/mysticalagriculture/tileentity/HarvesterTileEntity.java
@@ -209,7 +209,7 @@ public class HarvesterTileEntity extends BaseInventoryTileEntity implements Menu
     public static BaseItemStackHandler createInventoryHandler(OnContentsChangedFunction onContentsChanged) {
         return BaseItemStackHandler.create(16, onContentsChanged, builder -> {
             builder.setCanInsert((slot, stack) -> slot == 0 && stack.getBurnTime(null) > 0);
-            builder.setCanExtract(slot -> slot > 0);
+            builder.setCanExtract(slot -> slot > true);
         });
     }
 


### PR DESCRIPTION
you can put lava buckets into the harvester as fuel, but you cannot extract them afterwards from any side. this addresses the issue.