### PR TITLE
[Augments] [Bug] Fix invalid augment resource location registration

### DIFF
--- a/src/main/java/com/blakebr0/mysticalagriculture/registry/AugmentRegistry.java
+++ b/src/main/java/com/blakebr0/mysticalagriculture/registry/AugmentRegistry.java
@@ -50,7 +50,7 @@ public final class AugmentRegistry implements IAugmentRegistry {
         this.augments.forEach((id, a) -> {
             var item = new AugmentItem(a);
 
-            registry.register(id.withSuffix("_augment"), item);
+            registry.register(MysticalAgriculture.resource(a.getNameWithSuffix("augment")), item);
         });
 
         PluginRegistry.getInstance().forEach((plugin, config) -> plugin.onPostRegisterAugments(this));


### PR DESCRIPTION
## Summary

Fixed an issue where Augment items were being registered under their origin namespace's instead of Mystical Agriculture's. This is a bug because the rest of the API expects Augment items to be registered under the `mysticalagriculture` namespace.

This change does not impact the main mods, Mystical Agriculture & Mystical Agradditions.
* Mystical Agriculture's namespace is where all augments are added, so this will forever be unaffected.
* Mystical Agradditions adds no new augments, and is therefore unaffected.

This bug was introduced in the `1.20` -> `1.21` migration and only affects third-party mods looking to add custom augments.

<table>
  <thead>
    <tr>
      <th>1.20</th>
      <th>1.21</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>
        <img src="https://github.com/user-attachments/assets/e85ef605-0591-45be-8f18-ac95c91bfdc3"/>
      </td>
      <td>
        <img src="https://github.com/user-attachments/assets/7495a6ad-37c6-4a44-9b34-fb4e7cea5ada"/>
      </td>
    </tr>
  </tbody>
</table>